### PR TITLE
Add secret scanning + link checker workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,23 @@
+name: gitleaks
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,29 @@
+name: link-check
+
+on:
+  pull_request:
+  schedule:
+    - cron: '17 9 * * 1'  # Mondays
+
+permissions:
+  contents: read
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Link check (lychee)
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --accept 200,206,429
+            --exclude-mail
+            --max-retries 2
+            --timeout 20
+            --insecure
+            './**/*.md'


### PR DESCRIPTION
Adds two guardrails to prevent regressions:

- **Secret scanning** using `gitleaks` on PRs + pushes to `main`
- **Markdown link checking** using `lychee` on PRs + a weekly schedule
- Adds **Dependabot** config for GitHub Actions updates (weekly)

Notes:
- `gitleaks` action supports a paid license via `GITLEAKS_LICENSE`; if you don’t use one, it should still run in the default mode.
- Link checker is configured to scan `./**/*.md` and tolerate occasional rate-limits (429).