### PR TITLE
Career branding pages (Projects/Contact/Now) + site config refresh

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,4 +28,5 @@ jobs:
             --exclude ^https?://portal\\.azure\\.com
             --exclude ^https?://go\\.microsoft\\.com/fwlink
             --exclude ^https?://reddit\\.com
+            --exclude ^https?://(www\\.)?linkedin\\.com
             './**/*.md'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,5 +28,6 @@ jobs:
             --exclude ^https?://portal\\.azure\\.com
             --exclude ^https?://go\\.microsoft\\.com/fwlink
             --exclude ^https?://reddit\\.com
-            --exclude ^https?://(www\\.)?linkedin\\.com
+            --exclude ^https?://linkedin\\.com
+            --exclude ^https?://www\\.linkedin\\.com
             './**/*.md'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security
+
+This repository primarily contains blog content and reference material.
+
+## Reporting a vulnerability
+
+If you believe you’ve found a security issue in any code or artifacts in this repo:
+
+- Please **do not** open a public GitHub issue.
+- Instead, contact the maintainer via the **Contact** page on the site.
+
+## Secrets
+
+This repo uses automated secret scanning (gitleaks). Do not commit credentials, access tokens, or private keys.

--- a/_config.yml
+++ b/_config.yml
@@ -13,11 +13,9 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: CloudOps
+title: Principal Azure Cloud Architect
 email: adamd125@gmail.com
-description: >- # this means to ignore newlines until "baseurl:"
-  One stop shop to talk about Azure and architecture!
-twitter_username: aadost1
+twitter_username:twitter_username: aadost1
 github_username: adamdost-microsoft
 minimal_mistakes_skin: default
 search: true
@@ -29,7 +27,7 @@ remote_theme: mmistakes/minimal-mistakes
 permalink: /:categories/:title/
 paginate: 5 # amount of posts to show
 paginate_path: /page:num/
-timezone: US
+timezone: America/New_York
 
 include:
   - _pages
@@ -59,7 +57,7 @@ plugins:
 author:
   name   : "Adam Dost"
   avatar : "/assets/images/background.jpeg"
-  bio    : "Just trying to resolve blockers for those who are trying to strive for success. That and convince others to learn Linux."
+  bio    : "Principal Azure Cloud Architect focused on AI, automation, and networking. I design and ship secure-by-default solutions with guardrails so production doesn't start with compromises."
   links:
     - label: "Website"
       icon: "fas fa-fw fa-link"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,11 @@
 main:
   - title: "Posts"
     url: /posts/
-  - title: "Categories"
+  - title: "Topics"
     url: /categories/
+  - title: "Projects"
+    url: /projects/
   - title: "About"
     url: /about/
+  - title: "Contact"
+    url: /contact/

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -12,6 +12,7 @@ My specialty is building **production-ready Azure platforms** with **guardrails-
 
 ## What I’m good at
 
+- **AI & automation:** AI-enabled solutions, workflow automation, productivity tooling
 - **Networking & platform architecture:** hub-spoke, private endpoints, DNS, firewall patterns, secure connectivity
 - **Automation / IaC:** repeatable deployments, environment standardization, CI/CD guardrails
 - **Governance & security-by-default:** policy-as-code, compliance-aligned design, reducing drift and insecure defaults

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,15 +1,28 @@
 ---
-permalink: /about/
 title: "About"
+permalink: /about/
+layout: single
 ---
 
-````
-$ whoami
-````
-I'm a Sr. Cloud Solution's Architect at @microsoft.
+## Who I am
 
-I have worked in various Azure Enterprise Environment's in commercial and government and architected solutions inside of them. The two areas of Cloud I will always recommend individuals focus on first is **Networking** and **Identity**. These two core areas are the driving factor for a secure longterm cloud adoption.
+I’m a **Principal Azure Cloud Architect** focused on **AI, automation, and networking**.
 
-When I'm not at my machine I spend my free time playing the fun uncle and entertaining my two amazing nephews. I enjoy browsing reddit and engaging with other professionals over at [r/Azure](https://reddit.com/r/Azure) and [r/SysAdmin](https://reddit.com/r/SysAdmin) to help understand what others in the field are working through and learn vicariously from others mistakes.
+My specialty is building **production-ready Azure platforms** with **guardrails-first governance** (policy, security, and reliability controls) so teams can move fast without creating risk.
 
-My opinions are of my own and do not represent my employer. If you'd like to speak with me then send me a GitHub Message!
+## What I’m good at
+
+- **Networking & platform architecture:** hub-spoke, private endpoints, DNS, firewall patterns, secure connectivity
+- **Automation / IaC:** repeatable deployments, environment standardization, CI/CD guardrails
+- **Governance & security-by-default:** policy-as-code, compliance-aligned design, reducing drift and insecure defaults
+- **AI-enabled solutions:** pragmatic use of Azure AI services to improve delivery and operations
+
+## What this site is
+
+This repo backs my blog and portfolio. You’ll find:
+
+- posts explaining architecture decisions and tradeoffs
+- runnable examples (when practical)
+- diagrams and reference implementations
+
+If you’re a recruiter or hiring manager, start with **Projects** and **Contact**.

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -1,0 +1,17 @@
+---
+title: "Contact"
+permalink: /contact/
+layout: single
+---
+
+Best ways to reach me:
+
+- **LinkedIn:** (add link)
+- **Email:** (add address)
+
+If you’re contacting me about opportunities, please include:
+
+- role title + level
+- location / remote expectations
+- brief scope (platform, networking, security, AI, automation)
+- compensation range (if available)

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -6,8 +6,10 @@ layout: single
 
 Best ways to reach me:
 
-- **LinkedIn:** (add link)
-- **Email:** (add address)
+- **LinkedIn:** https://www.linkedin.com/in/adamadost
+- **Email:** Adam.dost@adost.dev
+
+**Location:** National Capital Region
 
 If you’re contacting me about opportunities, please include:
 

--- a/_pages/now.md
+++ b/_pages/now.md
@@ -1,0 +1,11 @@
+---
+title: "Now"
+permalink: /now/
+layout: single
+---
+
+A lightweight page for what I’m currently focused on.
+
+- Current focus: **AI-enabled Azure architecture + automation + networking**
+- Building: content and reference patterns that are secure-by-default
+- Open to: Principal/Lead architecture opportunities

--- a/_pages/now.md
+++ b/_pages/now.md
@@ -8,4 +8,5 @@ A lightweight page for what I’m currently focused on.
 
 - Current focus: **AI-enabled Azure architecture + automation + networking**
 - Building: content and reference patterns that are secure-by-default
+- Location: **National Capital Region**
 - Open to: Principal/Lead architecture opportunities

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -8,7 +8,12 @@ layout: single
 
 These are concise case studies designed for recruiters and hiring managers.
 
-### 1) Azure landing zone + guardrails-first governance
+### 1) AI + automation for platform operations
+- What: automation patterns and AI-enabled workflows for ops/dev productivity
+- Why it matters: faster delivery, fewer manual steps, safer changes
+- Proof: (add links to posts / diagrams / code here)
+
+### 2) Hub-spoke networking for private PaaS access
 - What: landing zone patterns, subscription organization, and policy guardrails
 - Why it matters: prevents insecure defaults and reduces configuration drift
 - Proof: (add links to posts / diagrams / code here)
@@ -18,7 +23,7 @@ These are concise case studies designed for recruiters and hiring managers.
 - Why it matters: reliable connectivity and secure data paths in production
 - Proof: (add links to posts / diagrams / code here)
 
-### 3) AI + automation for platform operations
-- What: automation patterns and AI-enabled workflows for ops/dev productivity
-- Why it matters: faster delivery, fewer manual steps, safer changes
+### 3) Azure landing zone + guardrails-first governance
+- What: landing zone patterns, subscription organization, and policy guardrails
+- Why it matters: prevents insecure defaults and reduces configuration drift
 - Proof: (add links to posts / diagrams / code here)

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -14,11 +14,6 @@ These are concise case studies designed for recruiters and hiring managers.
 - Proof: (add links to posts / diagrams / code here)
 
 ### 2) Hub-spoke networking for private PaaS access
-- What: landing zone patterns, subscription organization, and policy guardrails
-- Why it matters: prevents insecure defaults and reduces configuration drift
-- Proof: (add links to posts / diagrams / code here)
-
-### 2) Hub-spoke networking for private PaaS access
 - What: hub-spoke + firewall + private endpoints + DNS patterns
 - Why it matters: reliable connectivity and secure data paths in production
 - Proof: (add links to posts / diagrams / code here)

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,0 +1,24 @@
+---
+title: "Projects"
+permalink: /projects/
+layout: single
+---
+
+## Featured work
+
+These are concise case studies designed for recruiters and hiring managers.
+
+### 1) Azure landing zone + guardrails-first governance
+- What: landing zone patterns, subscription organization, and policy guardrails
+- Why it matters: prevents insecure defaults and reduces configuration drift
+- Proof: (add links to posts / diagrams / code here)
+
+### 2) Hub-spoke networking for private PaaS access
+- What: hub-spoke + firewall + private endpoints + DNS patterns
+- Why it matters: reliable connectivity and secure data paths in production
+- Proof: (add links to posts / diagrams / code here)
+
+### 3) AI + automation for platform operations
+- What: automation patterns and AI-enabled workflows for ops/dev productivity
+- Why it matters: faster delivery, fewer manual steps, safer changes
+- Proof: (add links to posts / diagrams / code here)


### PR DESCRIPTION
Implements recruiter-friendly funnel pages and updates navigation + site metadata for a clearer Principal Azure Cloud Architect brand.

Changes:
- Adds /projects, /contact, /now pages
- Updates About page to be direct + recruiter-readable
- Updates top nav (Topics/Projects/About/Contact)
- Refreshes site title/description/timezone + author bio
- Adds root SECURITY.md (how to report + no-secrets note)

Follow-ups (next PRs):
- Add OpenGraph/Twitter card image + more precise SEO metadata
- Add a lightweight writing guide for future posts (CONTRIBUTING addendum)
- Turn Projects placeholders into 2–3 real case studies with links/diagrams
