### PR TITLE
GTM UX: Topics grid homepage + Topics landing + post template (Bicep-first)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,10 @@ Thanks for your interest in contributing!
 
 ## Security
 If you believe you’ve found a security issue, please avoid public disclosure. Open a private report if possible.
+
+## Writing posts
+
+Use the engineering notebook template:
+- `docs/post-template.md`
+
+Guideline: keep posts practical (code + commands + validation), and call out guardrails/gotchas.

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,7 +2,7 @@ main:
   - title: "Posts"
     url: /posts/
   - title: "Topics"
-    url: /categories/
+    url: /topics/
   - title: "Projects"
     url: /projects/
   - title: "About"

--- a/_pages/topics.md
+++ b/_pages/topics.md
@@ -1,0 +1,16 @@
+---
+title: "Topics"
+permalink: /topics/
+layout: single
+---
+
+Pick a track:
+
+- [AI + Automation](/categories/#ai-automation)
+- [Networking](/categories/#networking)
+- [Governance / Guardrails](/categories/#governance-guardrails)
+- [IaC (Bicep)](/categories/#iac-bicep)
+- [Security](/categories/#security)
+- [Operations](/categories/#operations)
+
+> Tip: Each topic page is just a filter over posts. If you want a curated “Start here” list per topic, we can add that next.

--- a/docs/post-template.md
+++ b/docs/post-template.md
@@ -1,0 +1,40 @@
+# Post template (Engineering notebook)
+
+Copy this into a new file under `_posts/YYYY-MM-DD-title.md`.
+
+```yaml
+---
+title: "<Post title>"
+date: YYYY-MM-DD
+categories: [AI-Automation]  # or Networking, Governance-Guardrails, IaC-Bicep, Security, Operations
+tags: [Azure, Bicep, Policy]
+excerpt: "<1 sentence. What this teaches/builds and why it matters.>"
+toc: true
+toc_sticky: true
+---
+```
+
+## TL;DR
+- 
+
+## Goal / Why
+
+## Assumptions + scope
+
+## Architecture / approach
+
+## Implementation
+
+### Prereqs
+
+### Code
+
+### Commands
+
+## Guardrails
+
+## Validation (how I proved it works)
+
+## Gotchas
+
+## Next steps

--- a/index.html
+++ b/index.html
@@ -64,8 +64,3 @@ feature_row2:
 - Contact: [/contact/](/contact/)
 - Browse: [/topics/](/topics/)
 
----
-
-## Latest posts
-
-{% include posts-limit.html limit=5 %}

--- a/index.html
+++ b/index.html
@@ -1,7 +1,71 @@
 ---
-# You don't need to edit this file, it's empty on purpose.
-# Edit theme's home layout instead if you wanna make some changes
-# See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 layout: home
 author_profile: true
+header:
+  overlay_color: "#000"
+  overlay_filter: "0.55"
+  # You can swap this to a real hero image later (recommended for share polish PR)
+  # overlay_image: /assets/images/hero.jpg
+excerpt: "Principal Azure Cloud Architect focused on AI, automation, and networking. Guardrails-first, production-ready." 
+
+feature_row:
+  - image_path: /assets/images/bicep-mermaid-output.svg
+    alt: "AI + Automation"
+    title: "AI + Automation"
+    excerpt: "Practical automation patterns and AI-enabled workflows you can reuse."
+    url: /categories/#ai-automation
+    btn_label: "Explore"
+    btn_class: "btn--primary"
+  - image_path: /assets/images/bicep-mermaid-output.svg
+    alt: "Networking"
+    title: "Networking"
+    excerpt: "Hub-spoke, private endpoints, DNS, and secure connectivity patterns."
+    url: /categories/#networking
+    btn_label: "Explore"
+    btn_class: "btn--primary"
+  - image_path: /assets/images/bicep-mermaid-output.svg
+    alt: "Governance / Guardrails"
+    title: "Governance / Guardrails"
+    excerpt: "Policy-as-code and guardrails so production doesn’t start with compromises."
+    url: /categories/#governance-guardrails
+    btn_label: "Explore"
+    btn_class: "btn--primary"
+
+feature_row2:
+  - image_path: /assets/images/bicep-mermaid-output.svg
+    alt: "IaC (Bicep)"
+    title: "IaC (Bicep)"
+    excerpt: "Bicep-first infrastructure patterns with real code and validation steps."
+    url: /categories/#iac-bicep
+    btn_label: "Explore"
+    btn_class: "btn--primary"
+  - image_path: /assets/images/bicep-mermaid-output.svg
+    alt: "Security"
+    title: "Security"
+    excerpt: "Secure-by-default identity, networking, and platform controls."
+    url: /categories/#security
+    btn_label: "Explore"
+    btn_class: "btn--primary"
+  - image_path: /assets/images/bicep-mermaid-output.svg
+    alt: "Operations"
+    title: "Operations"
+    excerpt: "Runbooks, monitoring, reliability, and practical ops learnings."
+    url: /categories/#operations
+    btn_label: "Explore"
+    btn_class: "btn--primary"
 ---
+
+{% include feature_row %}
+{% include feature_row id="feature_row2" %}
+
+## Featured
+
+- Start here: [/projects/](/projects/)
+- Contact: [/contact/](/contact/)
+- Browse: [/topics/](/topics/)
+
+---
+
+## Latest posts
+
+{% include posts-limit.html limit=5 %}


### PR DESCRIPTION
Implements the engineering-notebook, recruiter-friendly GitHub Pages presentation we discussed.

Key changes:
- Homepage: topic-grid tiles in this order: AI+Automation (first), Networking (second), Governance/Guardrails, IaC (Bicep), Security, Operations
- Adds /topics landing page (clean entry point vs raw categories)
- Adds docs/post-template.md for consistent engineering notebook posts (code + commands + validation)
- Updates top nav to point Topics -> /topics
- CONTRIBUTING: links to the post template

Notes:
- Link-check excludes LinkedIn already (LinkedIn returns 999 to bots).