### PR TITLE
UX: curated topic pages (Start here) + branded topic tiles

### DIFF
--- a/_pages/topic-ai-automation.md
+++ b/_pages/topic-ai-automation.md
@@ -1,0 +1,13 @@
+---
+title: "AI + Automation"
+permalink: /topics/ai-automation/
+layout: single
+---
+
+## Start here
+
+- (Coming next) 1–3 featured posts that demonstrate real AI/automation work with code + validation.
+
+## Browse all posts
+
+- Category view: [/categories/#ai-automation](/categories/#ai-automation)

--- a/_pages/topic-governance-guardrails.md
+++ b/_pages/topic-governance-guardrails.md
@@ -1,0 +1,13 @@
+---
+title: "Governance / Guardrails"
+permalink: /topics/governance-guardrails/
+layout: single
+---
+
+## Start here
+
+- (Coming next) Policy-as-code, standards, and “safe defaults” patterns you can reuse.
+
+## Browse all posts
+
+- Category view: [/categories/#governance-guardrails](/categories/#governance-guardrails)

--- a/_pages/topic-iac-bicep.md
+++ b/_pages/topic-iac-bicep.md
@@ -1,0 +1,13 @@
+---
+title: "IaC (Bicep)"
+permalink: /topics/iac-bicep/
+layout: single
+---
+
+## Start here
+
+- (Coming next) Bicep-first modules and practical deployments.
+
+## Browse all posts
+
+- Category view: [/categories/#iac-bicep](/categories/#iac-bicep)

--- a/_pages/topic-networking.md
+++ b/_pages/topic-networking.md
@@ -1,0 +1,13 @@
+---
+title: "Networking"
+permalink: /topics/networking/
+layout: single
+---
+
+## Start here
+
+- (Coming next) Hub-spoke + private endpoints + DNS patterns, written as engineering notebooks.
+
+## Browse all posts
+
+- Category view: [/categories/#networking](/categories/#networking)

--- a/_pages/topic-operations.md
+++ b/_pages/topic-operations.md
@@ -1,0 +1,13 @@
+---
+title: "Operations"
+permalink: /topics/operations/
+layout: single
+---
+
+## Start here
+
+- (Coming next) Monitoring, reliability, and operational learnings.
+
+## Browse all posts
+
+- Category view: [/categories/#operations](/categories/#operations)

--- a/_pages/topic-security.md
+++ b/_pages/topic-security.md
@@ -1,0 +1,13 @@
+---
+title: "Security"
+permalink: /topics/security/
+layout: single
+---
+
+## Start here
+
+- (Coming next) Identity, secrets, and security-by-default guardrails.
+
+## Browse all posts
+
+- Category view: [/categories/#security](/categories/#security)

--- a/_pages/topics.md
+++ b/_pages/topics.md
@@ -6,11 +6,12 @@ layout: single
 
 Pick a track:
 
-- [AI + Automation](/categories/#ai-automation)
-- [Networking](/categories/#networking)
-- [Governance / Guardrails](/categories/#governance-guardrails)
-- [IaC (Bicep)](/categories/#iac-bicep)
-- [Security](/categories/#security)
-- [Operations](/categories/#operations)
+1) **AI + Automation** — [/topics/ai-automation/](/topics/ai-automation/)
+2) **Networking** — [/topics/networking/](/topics/networking/)
+3) **Governance / Guardrails** — [/topics/governance-guardrails/](/topics/governance-guardrails/)
+4) **IaC (Bicep)** — [/topics/iac-bicep/](/topics/iac-bicep/)
+5) **Security** — [/topics/security/](/topics/security/)
+6) **Operations** — [/topics/operations/](/topics/operations/)
 
-> Tip: Each topic page is just a filter over posts. If you want a curated “Start here” list per topic, we can add that next.
+If you prefer the raw category listing:
+- [/categories/](/categories/)

--- a/assets/images/topics/ai-automation.svg
+++ b/assets/images/topics/ai-automation.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ea5e9"/>
+      <stop offset="1" stop-color="#1e3a8a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.95" font-family="Segoe UI, Roboto, Arial" >
+    <text x="80" y="210" font-size="64" font-weight="700">AI + Automation</text>
+    <text x="80" y="290" font-size="32" opacity="0.9">Practical patterns • scripts • repeatable workflows</text>
+  </g>
+  <g fill="none" stroke="#ffffff" stroke-width="10" opacity="0.9">
+    <path d="M900 150h180v180H900z"/>
+    <path d="M990 150v180"/>
+    <path d="M900 240h180"/>
+  </g>
+</svg>

--- a/assets/images/topics/governance-guardrails.svg
+++ b/assets/images/topics/governance-guardrails.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f97316"/>
+      <stop offset="1" stop-color="#7c2d12"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.95" font-family="Segoe UI, Roboto, Arial" >
+    <text x="80" y="210" font-size="64" font-weight="700">Governance / Guardrails</text>
+    <text x="80" y="290" font-size="32" opacity="0.9">Policy-as-code • standards • safe defaults</text>
+  </g>
+  <g fill="none" stroke="#ffffff" stroke-width="10" opacity="0.9">
+    <path d="M980 150 l140 60 v80c0 90-80 150-140 170c-60-20-140-80-140-170v-80z"/>
+  </g>
+</svg>

--- a/assets/images/topics/iac-bicep.svg
+++ b/assets/images/topics/iac-bicep.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#a78bfa"/>
+      <stop offset="1" stop-color="#4c1d95"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.95" font-family="Segoe UI, Roboto, Arial" >
+    <text x="80" y="210" font-size="64" font-weight="700">IaC (Bicep)</text>
+    <text x="80" y="290" font-size="32" opacity="0.9">Bicep-first examples with validation steps</text>
+  </g>
+  <g fill="none" stroke="#ffffff" stroke-width="10" opacity="0.9">
+    <path d="M900 160h220v60H900z"/>
+    <path d="M900 260h220v60H900z"/>
+    <path d="M900 360h220v60H900z"/>
+  </g>
+</svg>

--- a/assets/images/topics/networking.svg
+++ b/assets/images/topics/networking.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#22c55e"/>
+      <stop offset="1" stop-color="#14532d"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.95" font-family="Segoe UI, Roboto, Arial" >
+    <text x="80" y="210" font-size="64" font-weight="700">Networking</text>
+    <text x="80" y="290" font-size="32" opacity="0.9">Hub-spoke • Private Endpoints • DNS • Firewall</text>
+  </g>
+  <g stroke="#ffffff" stroke-width="10" opacity="0.9" fill="none">
+    <circle cx="920" cy="220" r="36"/>
+    <circle cx="1040" cy="180" r="36"/>
+    <circle cx="1060" cy="300" r="36"/>
+    <path d="M952 220 L1004 192"/>
+    <path d="M952 220 L1024 274"/>
+    <path d="M1076 214 L1088 264"/>
+  </g>
+</svg>

--- a/assets/images/topics/operations.svg
+++ b/assets/images/topics/operations.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#94a3b8"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.95" font-family="Segoe UI, Roboto, Arial" >
+    <text x="80" y="210" font-size="64" font-weight="700">Operations</text>
+    <text x="80" y="290" font-size="32" opacity="0.9">Monitoring • reliability • runbooks • incident learnings</text>
+  </g>
+  <g fill="none" stroke="#ffffff" stroke-width="10" opacity="0.9">
+    <path d="M940 300h240"/>
+    <path d="M940 300c0-80 80-140 160-140 80 0 80 50 80 50"/>
+    <path d="M1060 350v120"/>
+    <path d="M1020 470h80"/>
+  </g>
+</svg>

--- a/assets/images/topics/security.svg
+++ b/assets/images/topics/security.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ef4444"/>
+      <stop offset="1" stop-color="#7f1d1d"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <g fill="#ffffff" opacity="0.95" font-family="Segoe UI, Roboto, Arial" >
+    <text x="80" y="210" font-size="64" font-weight="700">Security</text>
+    <text x="80" y="290" font-size="32" opacity="0.9">Identity • secrets • secure networking • logging</text>
+  </g>
+  <g fill="none" stroke="#ffffff" stroke-width="10" opacity="0.9">
+    <rect x="940" y="170" width="200" height="210" rx="24"/>
+    <path d="M990 170v-30c0-35 30-60 60-60s60 25 60 60v30"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -9,48 +9,48 @@ header:
 excerpt: "Principal Azure Cloud Architect focused on AI, automation, and networking. Guardrails-first, production-ready." 
 
 feature_row:
-  - image_path: /assets/images/bicep-mermaid-output.svg
+  - image_path: /assets/images/topics/ai-automation.svg
     alt: "AI + Automation"
     title: "AI + Automation"
     excerpt: "Practical automation patterns and AI-enabled workflows you can reuse."
-    url: /categories/#ai-automation
+    url: /topics/ai-automation/
     btn_label: "Explore"
     btn_class: "btn--primary"
-  - image_path: /assets/images/bicep-mermaid-output.svg
+  - image_path: /assets/images/topics/networking.svg
     alt: "Networking"
     title: "Networking"
     excerpt: "Hub-spoke, private endpoints, DNS, and secure connectivity patterns."
-    url: /categories/#networking
+    url: /topics/networking/
     btn_label: "Explore"
     btn_class: "btn--primary"
-  - image_path: /assets/images/bicep-mermaid-output.svg
+  - image_path: /assets/images/topics/governance-guardrails.svg
     alt: "Governance / Guardrails"
     title: "Governance / Guardrails"
     excerpt: "Policy-as-code and guardrails so production doesn’t start with compromises."
-    url: /categories/#governance-guardrails
+    url: /topics/governance-guardrails/
     btn_label: "Explore"
     btn_class: "btn--primary"
 
 feature_row2:
-  - image_path: /assets/images/bicep-mermaid-output.svg
+  - image_path: /assets/images/topics/iac-bicep.svg
     alt: "IaC (Bicep)"
     title: "IaC (Bicep)"
     excerpt: "Bicep-first infrastructure patterns with real code and validation steps."
-    url: /categories/#iac-bicep
+    url: /topics/iac-bicep/
     btn_label: "Explore"
     btn_class: "btn--primary"
-  - image_path: /assets/images/bicep-mermaid-output.svg
+  - image_path: /assets/images/topics/security.svg
     alt: "Security"
     title: "Security"
     excerpt: "Secure-by-default identity, networking, and platform controls."
-    url: /categories/#security
+    url: /topics/security/
     btn_label: "Explore"
     btn_class: "btn--primary"
-  - image_path: /assets/images/bicep-mermaid-output.svg
+  - image_path: /assets/images/topics/operations.svg
     alt: "Operations"
     title: "Operations"
     excerpt: "Runbooks, monitoring, reliability, and practical ops learnings."
-    url: /categories/#operations
+    url: /topics/operations/
     btn_label: "Explore"
     btn_class: "btn--primary"
 ---


### PR DESCRIPTION
DevSecOps mindset: small, auditable change; verify real CI runs.

What this does:
- Adds curated topic landing pages under /topics/* so readers (and recruiters) have a clear 'Start here' per track.
- Replaces placeholder homepage tile images with lightweight branded SVG tiles (per topic).
- Keeps raw /categories as a fallback.

Notes:
- Topic order remains: AI+Automation, Networking, Governance/Guardrails, IaC (Bicep), Security, Operations.
- Curated lists are placeholders for now; next PR can fill with real 'Start here' links once we pick 1–3 flagship posts per topic.
