### PR TITLE
Fix Dependabot pip updates (python-container-dev)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Keep the Python sample dependencies in a secure, modern range.
+  - package-ecosystem: "pip"
+    directory: "/python-container-dev"
+    schedule:
+      interval: "weekly"

--- a/python-container-dev/requirements.txt
+++ b/python-container-dev/requirements.txt
@@ -1,16 +1,13 @@
-Flask>=1,<2
-werkzeug>=1,<2
-flask-session~=0.3.2
+# NOTE: This repo keeps this sample as Python 3+.
+# The Flask/Werkzeug <2 pins caused Dependabot security updates to fail.
+# If you need legacy Python 2.x compatibility, use the upstream historical version.
+
+Flask>=2.2,<3
+Werkzeug>=2.2,<3
+flask-session>=0.5,<1
 requests>=2,<3
 msal>=1.7,<2
-uuid>=1
+
+# stdlib: uuid
 azure-identity
 azure-keyvault-secrets
-# cachelib==0.1  # Only need this if you are running Python 2
-# Note: This sample does NOT directly depend on cachelib.
-# It is an indirect dependency of flask-session.
-# Cachelib 0.1.1 no longer supports Python 2
-# (see also https://github.com/pallets/cachelib/issues/14)
-# So, if you still need to run your app in Python 2,
-# your workaround is to pin cachelib to its older version 0.1,
-# but keep in mind it contains a known bug https://github.com/pallets/cachelib/pull/12


### PR DESCRIPTION
Why:\n- Dependabot Updates is failing on a pip update in /python-container-dev (Werkzeug).\n- The sample was pinned to Flask/Werkzeug <2, which blocks security updates.\n\nWhat changed:\n- Modernized python-container-dev/requirements.txt to Flask/Werkzeug 2.x (Python 3+).\n- Removed incorrect pip dependency on stdlib 'uuid'.\n- Added pip ecosystem to .github/dependabot.yml so Dependabot version updates run explicitly for /python-container-dev.\n\nNotes:\n- No runtime CI currently exercises the Python sample; this is intended to unblock Dependabot and reduce security risk.