### PR TITLE
Refresh landing page profile treatment

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -90,10 +90,11 @@ a {
   position: relative;
   overflow: hidden;
   isolation: isolate;
+  // Minimal Mistakes emits an inline empty url() when overlay_image is absent.
   background:
     radial-gradient(circle at 82% 18%, rgba(56, 189, 248, 0.24), transparent 24rem),
     radial-gradient(circle at 12% 82%, rgba(14, 165, 233, 0.18), transparent 20rem),
-    linear-gradient(135deg, #0f172a 0%, #0b3b69 56%, #0067b8 100%);
+    linear-gradient(135deg, #0f172a 0%, #0b3b69 56%, #0067b8 100%) !important;
 }
 
 .landing-page .page__hero--overlay::after {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -86,6 +86,37 @@ a {
   max-width: 52rem;
 }
 
+.landing-page .page__hero--overlay {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    radial-gradient(circle at 82% 18%, rgba(56, 189, 248, 0.24), transparent 24rem),
+    radial-gradient(circle at 12% 82%, rgba(14, 165, 233, 0.18), transparent 20rem),
+    linear-gradient(135deg, #0f172a 0%, #0b3b69 56%, #0067b8 100%);
+}
+
+.landing-page .page__hero--overlay::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(120deg, transparent 0%, #000 28%, #000 72%, transparent 100%);
+  opacity: 0.42;
+}
+
+.landing-page .page__hero--overlay .page__title {
+  max-width: 16ch;
+}
+
+.landing-page .page__hero--overlay .page__excerpt {
+  max-width: 46rem;
+}
+
 .btn--primary,
 .btn--success,
 .btn--info,
@@ -116,11 +147,16 @@ a {
 .archive__item,
 .landing-card,
 .landing-band,
+.landing-profile-card,
 .landing-posts li {
   border-radius: 18px;
 }
 
 .author__avatar img {
+  width: min(100%, 120px);
+  max-width: 120px;
+  aspect-ratio: 1;
+  object-fit: cover;
   border: 1px solid var(--azure-line);
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
 }
@@ -130,6 +166,7 @@ a {
 .archive__item,
 .landing-card,
 .landing-band,
+.landing-profile-card,
 .landing-posts li {
   border: 1px solid var(--azure-line);
   box-shadow: var(--azure-shadow);
@@ -236,6 +273,52 @@ a {
   background: linear-gradient(135deg, #f8fbff 0%, #eef6ff 100%);
 }
 
+.landing-intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+  gap: 1rem;
+  align-items: stretch;
+  margin: 2rem 0;
+}
+
+.landing-intro .landing-band {
+  margin: 0;
+}
+
+.landing-band--intro {
+  display: flex;
+  align-items: center;
+}
+
+.landing-profile-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1rem;
+  align-items: center;
+  padding: 1.25rem;
+}
+
+.landing-profile-card__avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid #fff;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.14);
+}
+
+.landing-profile-card__body h2 {
+  margin: 0.25rem 0 0.35rem;
+  font-size: 1.25rem;
+}
+
+.landing-profile-card__body p {
+  margin-bottom: 0;
+  color: var(--azure-slate);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
 .landing-band--cta {
   background: linear-gradient(135deg, #0f172a 0%, #0b3b69 100%);
   color: #fff;
@@ -323,5 +406,28 @@ a {
 @media (max-width: 768px) {
   .page__hero--overlay {
     padding: 4.5rem 0 3.5rem;
+  }
+
+  .landing-intro {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-profile-card {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .landing-profile-card {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .landing-profile-card__avatar {
+    margin: 0 auto;
+  }
+
+  .landing-card__eyebrow {
+    margin-left: 0;
   }
 }

--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@ classes:
   - landing-page
 header:
   overlay_color: "#0f172a"
-  overlay_filter: "0.6"
-  overlay_image: /assets/images/background.jpeg
+  overlay_filter: "0.68"
   actions:
     - label: "Review project work"
       url: "/projects/"
@@ -64,11 +63,28 @@ feature_row2:
     btn_class: "btn--primary"
 ---
 
-<div class="landing-band">
-  <p class="landing-lead">
-    I help teams turn Azure intent into operating platforms: landing zones, secure networking, IaC delivery,
-    and governance guardrails that hold up under real production pressure.
-  </p>
+<div class="landing-intro">
+  <div class="landing-band landing-band--intro">
+    <p class="landing-lead">
+      I help teams turn Azure intent into operating platforms: landing zones, secure networking, IaC delivery,
+      and governance guardrails that hold up under real production pressure.
+    </p>
+  </div>
+
+  <aside class="landing-profile-card" aria-label="Profile summary">
+    <img
+      class="landing-profile-card__avatar"
+      src="{{ '/assets/images/bio-photo.jpg' | relative_url }}"
+      width="128"
+      height="128"
+      alt="Adam Dost"
+    >
+    <div class="landing-profile-card__body">
+      <span class="landing-card__eyebrow">Profile</span>
+      <h2>Adam Dost</h2>
+      <p>Microsoft Principal Architect focused on Azure landing zones, secure platforms, and operationally sound delivery.</p>
+    </div>
+  </aside>
 </div>
 
 <div class="landing-grid">


### PR DESCRIPTION
## Summary
- Replace the landing page's full-bleed photo treatment with a scoped Azure/cloud gradient hero.
- Add a compact profile card for Adam's headshot with explicit avatar sizing.
- Add landing-scoped responsive CSS and defensive Minimal Mistakes author avatar caps.

## Test Plan
- [x] Built the Jekyll site with `bundle exec jekyll build --trace` in a Ruby Docker container.
- [x] Verified generated `_site/index.html` includes `landing-profile-card` and `bio-photo.jpg` without `background.jpeg`.
- [x] Ran Playwright layout assertions at 1440x1000 and 390x844: avatar <=128px, no horizontal scroll, hero computed background has no `url(`.
- [x] Captured desktop/mobile screenshots from an HTTP-served `_site` build.